### PR TITLE
Next matchers

### DIFF
--- a/Example/ExampleTests/ExampleTests.swift
+++ b/Example/ExampleTests/ExampleTests.swift
@@ -43,6 +43,7 @@ class ExampleTests: XCTestCase {
         scheduler.bind(events, to: viewModel.input)
         scheduler.start()
         assert(source).next()
+        assert(source).next(at: 10)
     }
 
     func testNotSentNext() {

--- a/Example/ExampleTests/ExampleTests.swift
+++ b/Example/ExampleTests/ExampleTests.swift
@@ -49,6 +49,15 @@ class ExampleTests: XCTestCase {
         assert(source).next(at: 0, equal: "alpha")
     }
 
+    func testNextEventsHelpers() {
+        let events = [next(10, "alpha"), next(12, "bravo"), completed(15)]
+        let source = scheduler.record(source: viewModel.elements)
+        scheduler.bind(events, to: viewModel.input)
+        scheduler.start()
+        assert(source) == "alpha"
+        assert(source).firstNext(equal: "alpha")
+        assert(source).lastNext(equal: "bravo")
+    }
     func testNotSentNext() {
         let events: [Recorded<Event<String>>] = [completed(10)]
         let source = scheduler.record(source: viewModel.elements)

--- a/Example/ExampleTests/ExampleTests.swift
+++ b/Example/ExampleTests/ExampleTests.swift
@@ -44,6 +44,7 @@ class ExampleTests: XCTestCase {
         scheduler.start()
         assert(source).next()
         assert(source).next(at: 10)
+        assert(source).next(times: 1)
     }
 
     func testNotSentNext() {

--- a/Example/ExampleTests/ExampleTests.swift
+++ b/Example/ExampleTests/ExampleTests.swift
@@ -45,6 +45,8 @@ class ExampleTests: XCTestCase {
         assert(source).next()
         assert(source).next(at: 10)
         assert(source).next(times: 1)
+
+        assert(source).next(at: 0, equal: "alpha")
     }
 
     func testNotSentNext() {

--- a/RxTestExt/Assertion.swift
+++ b/RxTestExt/Assertion.swift
@@ -37,11 +37,20 @@ public func assert<T>(_ source: TestableObserver<T>, file: StaticString = #file,
     return Assertion(source, file: file, line: line)
 }
 
+// MARK: Next Matchers
 extension Assertion {
     /// A matcher that succeeds when testable observer received one (or more) next events
     public func next() {
         verify(pass: events.first?.value.element != nil,
                message: "next")
+    }
+
+    /// A matcher that succeeds when testable observer receives a next event at a specific time.
+    ///
+    /// - Parameter time: Expected `next` time.
+    public func next(at time: TestTime) {
+        verify(pass: !events.filter { $0.time == time && $0.value.element != nil }.isEmpty,
+               message: "next at <\(time)>")
     }
 }
 

--- a/RxTestExt/Assertion.swift
+++ b/RxTestExt/Assertion.swift
@@ -63,6 +63,26 @@ extension Assertion {
     }
 }
 
+// MARK: Next Equality Matchers
+extension Assertion where T: Equatable {
+    /// A matcher that succeeds when value emitted at a specific index equal a given value.
+    ///
+    /// - Parameters:
+    ///   - index: Event index.
+    ///   - expectedValue: Expected value.
+    public func next(at index: Int, equal expectedValue: T) {
+        let nextEvents = events.filter { $0.value.element != nil }
+        guard nextEvents.count > index else {
+            verify(pass: false,
+                   message: "get enough next events")
+            return
+        }
+        let actualValue = nextEvents[index].value.element
+        verify(pass: actualValue == expectedValue,
+               message: "equal <\(expectedValue)>, got <\(actualValue.stringify)>")
+    }
+}
+
 // MARK: Error Matchers
 extension Assertion {
     /// A matcher that succeeds when testable observer terminated with an error event

--- a/RxTestExt/Assertion.swift
+++ b/RxTestExt/Assertion.swift
@@ -72,7 +72,7 @@ extension Assertion where T: Equatable {
     ///   - expectedValue: Expected value.
     public func next(at index: Int, equal expectedValue: T) {
         let nextEvents = events.filter { $0.value.element != nil }
-        guard nextEvents.count > index else {
+        guard nextEvents.count > index, index >= 0 else {
             verify(pass: false,
                    message: "get enough next events")
             return
@@ -81,6 +81,25 @@ extension Assertion where T: Equatable {
         verify(pass: actualValue == expectedValue,
                message: "equal <\(expectedValue)>, got <\(actualValue.stringify)>")
     }
+
+    /// A matcher that succeeds when last emitted next is equal to given value.
+    ///
+    /// - Parameter expectedValue: Expected value.
+    public func lastNext(equal expectedValue: T) {
+        let nextEvents = events.filter { $0.value.element != nil }
+        next(at: nextEvents.count - 1, equal: expectedValue)
+    }
+
+    /// A matcher that succeeds when first emitted next is equal to given value.
+    ///
+    /// - Parameter expectedValue: Expected value.
+    public func firstNext(equal expectedValue: T) {
+        next(at: 0, equal: expectedValue)
+    }
+}
+
+public func == <T: Equatable>(lhs: Assertion<T>, rhs: T) {
+    lhs.firstNext(equal: rhs)
 }
 
 // MARK: Error Matchers

--- a/RxTestExt/Assertion.swift
+++ b/RxTestExt/Assertion.swift
@@ -52,6 +52,15 @@ extension Assertion {
         verify(pass: !events.filter { $0.time == time && $0.value.element != nil }.isEmpty,
                message: "next at <\(time)>")
     }
+
+    /// A matcher that succeeds when testable observer recieves a specific number of next events.
+    ///
+    /// - Parameter expectedCount: Expected number of next events.
+    public func next(times expectedCount: Int) {
+        let actualCount = events.filter { $0.value.element != nil }.count
+        verify(pass: actualCount == expectedCount,
+               message: "next <\(expectedCount)> times, got <\(actualCount)> event(s)")
+    }
 }
 
 // MARK: Error Matchers

--- a/RxTestExt/Utils.swift
+++ b/RxTestExt/Utils.swift
@@ -1,0 +1,10 @@
+extension Optional {
+    var stringify: String {
+        switch self {
+        case .none:
+            return ""
+        case .some(let value):
+            return "\(value)"
+        }
+    }
+}


### PR DESCRIPTION
Add matchers for next events,
- send next event at specific time.
- send specific number of next events.
- match specific next event is equal to a value.
- match first next event is equal to value.
- match last next event is equal to value.